### PR TITLE
Add %e format specifier for printing the pkgbase

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -122,6 +122,8 @@ The format argument allows the following interpreted sequences:
 
   %d    description
 
+  %e    package base
+
   %f    filename (only with -S)
 
   %g    base64 encoded PGP signature (only with -S)

--- a/expac.c
+++ b/expac.c
@@ -450,6 +450,9 @@ static void print_pkg(alpm_pkg_t *pkg, const char *format)
         case 'f': /* filename */
           out += printf(fmt, alpm_pkg_get_filename(pkg));
           break;
+        case 'e': /* package base */
+          out += printf(fmt, alpm_pkg_get_base(pkg));
+          break;
         case 'n': /* package name */
           out += printf(fmt, alpm_pkg_get_name(pkg));
           break;


### PR DESCRIPTION
Seeing as how it’s now merged in pacman git.

If you want a different format specifier I can change it.