### PR TITLE
add missing versioned 'Conflict with' formatter

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -92,7 +92,7 @@ The format argument allows the following interpreted sequences:
 
   %B    backup files
 
-  %C    conflicts with
+  %C    conflicts with (no version strings)
 
   %D    depends on
 
@@ -101,6 +101,8 @@ The format argument allows the following interpreted sequences:
   %F    files (only with -Q)
 
   %G    groups
+
+  %H    conflicts with
 
   %L    licenses
 

--- a/expac.c
+++ b/expac.c
@@ -532,7 +532,10 @@ static void print_pkg(alpm_pkg_t *pkg, const char *format)
         case 'o': /* optdepends (shortdeps) */
           out += print_list(alpm_pkg_get_optdepends(pkg), (extractfn)alpm_dep_get_name);
           break;
-        case 'C': /* conflicts */
+        case 'H': /* conflicts */
+          out += print_list(alpm_pkg_get_conflicts(pkg), (extractfn)alpm_dep_compute_string);
+          break;
+        case 'C': /* conflicts (shortdeps) */
           out += print_list(alpm_pkg_get_conflicts(pkg), (extractfn)alpm_dep_get_name);
           break;
         case 'S': /* provides (shortdeps) */


### PR DESCRIPTION
As of today, expac is only providing a "conflict with" formatter (```%C```) without string, but does not provide a formatter with version strings as done with  "depends on" and "provides".

This user case is relatively rare, but does exist (see for example "xorg-server" and "python2"). Here is a tiny patch that adds this missing feature. I choose ```%H``` as the next available sequence.