### PR TITLE
parse_options: return -1 on invalid size unit

### DIFF
--- a/expac.c
+++ b/expac.c
@@ -203,7 +203,7 @@ static int parse_options(int *argc, char **argv[])
       case 'H':
         if(!is_valid_size_unit(optarg)) {
           fprintf(stderr, "error: invalid SI size formatter: %s\n", optarg);
-          return 1;
+          return -1;
         }
         opt_humansize = *optarg;
         break;


### PR DESCRIPTION
parse_options immediately exits on an invalid size unit, preventing it
from setting opt_format or updating argc and argv.  main only checks for
a return less than 0 to determine failure, causing it to continue
without a format and treating all arguments, including options, as
target packages.  If one of the arguments happens to match an available
package, such as "expac" in argv[0], expac will attempt to print it with
a NULL format, causing a segfault.