### PR TITLE
using ISO 8601 format output time for easy sorting

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -73,7 +73,7 @@ Interpret targets as paths to local files.
 =item B<-t, --timefmt> <format>
 
 Output time described by the specified I<format>. This string is passed directly
-to strftime(3). The default format is %c.
+to strftime(3). The default format is %FT%T.
 
 =item B<-v, --verbose>
 
@@ -182,7 +182,7 @@ List the oldest 10 installed packages (by build date):
 
 =over 4
 
-  $ expac --timefmt=%s '%b\t%n' | sort -n | head -10
+  $ expac '%b\t%n' | sort | head -10
 
 =back
 

--- a/expac.c
+++ b/expac.c
@@ -42,7 +42,7 @@
 
 #define DEFAULT_DELIM        "\n"
 #define DEFAULT_LISTDELIM    "  "
-#define DEFAULT_TIMEFMT      "%c"
+#define DEFAULT_TIMEFMT      "%FT%T"
 #define SIZE_TOKENS          "BKMGTPEZY\0"
 
 #ifndef PATH_MAX
@@ -147,7 +147,7 @@ static void usage(void)
       "  -d, --delim <string>      separator used between packages (default: \"\\n\")\n"
       "  -l, --listdelim <string>  separator used between list elements (default: \"  \")\n"
       "  -p, --file                query local files instead of the DB\n"
-      "  -t, --timefmt <fmt>       date format passed to strftime (default: \"%%c\")\n"
+      "  -t, --timefmt <fmt>       date format passed to strftime (default: \"%%FT%%T\")\n"
       "      --config <file>       read from <file> for alpm initialization (default: /etc/pacman.conf)\n\n"
       "  -v, --verbose             be more verbose\n\n"
       "  -h, --help                display this help and exit\n\n"


### PR DESCRIPTION
`%FT%T` format output like `2017-10-04T11:20:20`, that easy to sorting by time without pass arguments.