### PR TITLE
Fixed read_targets_from_file() for ARM arch

### DIFF
--- a/expac.c
+++ b/expac.c
@@ -798,12 +798,13 @@ static alpm_list_t *expac_search(expac_t *expac, package_corpus_t corpus, alpm_l
 static int read_targets_from_file(FILE *in, alpm_list_t **targets)
 {
   char line[BUFSIZ];
-  int i = 0, end = 0, targets_added = 0;
+  int c, i = 0, end = 0, targets_added = 0;
 
   while(!end) {
-    line[i] = fgetc(in);
+    c = fgetc(in);
+    line[i] = c;
 
-    if(line[i] == EOF)
+    if(c == EOF)
       end = 1;
 
     if(isspace(line[i]) || end) {


### PR DESCRIPTION
Before this fix reading from stdin caused this error:
```
error: buffer overflow on stdin
```
... bacause char is unsigned on ARM (for example on Raspberry Pi).

This error could be observed while compilation:
```
expac.c: In function ‘read_targets_from_file’:
expac.c:806:16: warning: comparison is always false due to limited range of data type [-Wtype-limits]
     if(line[i] == EOF)
```