### PR TITLE
use feof to check for EOF when reading from stream

### DIFF
--- a/expac.c
+++ b/expac.c
@@ -803,7 +803,7 @@ static int read_targets_from_file(FILE *in, alpm_list_t **targets)
   while(!end) {
     line[i] = fgetc(in);
 
-    if(line[i] == EOF)
+    if(feof(in))
       end = 1;
 
     if(isspace(line[i]) || end) {


### PR DESCRIPTION
Hey!

see: https://github.com/polygamma/aurman/issues/200

Due to the usage of signed chars on ARM, https://github.com/falconindy/expac/blob/master/expac.c#L806 can never be true, ending in an endless loop, as can be seen in the mentioned issue. This PR fixes the problem, by using `feof` to detect the `EOF`. I tested, that this indeed fixes the problem, see: https://github.com/polygamma/aurman/issues/200#issuecomment-402704777

It is nevertheless nicer to use `feof` in that case, regardless of the bug.