### PR TITLE
Make --humansize more like pacman's default behaviour

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -49,7 +49,7 @@ Read from I<file> for alpm initialization instead of I</etc/pacman.conf>.
 
 Format package sizes in SI units according to I<size>. Valid options are:
 
-  B, K, M, G, T, P, E, Z, Y
+  auto, B, K, M, G, T, P, E, Z, Y, R, Q
 
 =item B<-1, --readone>
 


### PR DESCRIPTION
`--humansize` argument is made optional; I've made sure that existing uses of it aren't broken, while in a more natural form for the CLI, when --humansize is given without an SI-ish prefix as an argument, it finds an appropriate unit for each size. eg:

```
$ expac -H K %m expac pacman
33.30 KiB
4897.76 KiB
$ expac --humansize M %m expac pacman
0.03 MiB
4.78 MiB
$ expac -H %m expac pacman
33.30 KiB
4.78 MiB
```
