### PR TITLE
Add format attributes for optionalfor, makedepends and checkdepends

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -106,10 +106,6 @@ The format argument allows the following interpreted sequences:
 
   %D    depends on
 
-  %J    make depends on
-
-  %K    check depends on
-
   %d    description
 
   %E    depends on (no version strings)
@@ -130,6 +126,10 @@ The format argument allows the following interpreted sequences:
 
   %i    has install scriptlet (only with -Q)
 
+  %J    make depends on
+
+  %K    check depends on
+
   %k    download size (only with -S)
 
   %l    install date (only with -Q)
@@ -143,8 +143,6 @@ The format argument allows the following interpreted sequences:
   %n    package name
 
   %N    required by
-
-  %W    optional for
 
   %O    optional deps
 
@@ -169,6 +167,8 @@ The format argument allows the following interpreted sequences:
   %V    package validation method
 
   %v    version
+
+  %W    optional for
 
   %w    install reason (only with -Q)
 

--- a/README.pod
+++ b/README.pod
@@ -106,6 +106,10 @@ The format argument allows the following interpreted sequences:
 
   %D    depends on
 
+  %J    make depends on
+
+  %K    check depends on
+
   %d    description
 
   %E    depends on (no version strings)
@@ -139,6 +143,8 @@ The format argument allows the following interpreted sequences:
   %n    package name
 
   %N    required by
+
+  %W    optional for
 
   %O    optional deps
 

--- a/src/expac.c
+++ b/src/expac.c
@@ -537,6 +537,9 @@ static void print_pkg(alpm_pkg_t *pkg, const char *format)
         case 'N': /* requiredby */
           out += print_list(alpm_pkg_compute_requiredby(pkg), NULL);
           break;
+        case 'W': /* optionalfor */
+          out += print_list(alpm_pkg_compute_optionalfor(pkg), NULL);
+          break;
         case 'L': /* licenses */
           out += print_list(alpm_pkg_get_licenses(pkg), NULL);
           break;
@@ -545,6 +548,12 @@ static void print_pkg(alpm_pkg_t *pkg, const char *format)
           break;
         case 'E': /* depends (shortdeps) */
           out += print_list(alpm_pkg_get_depends(pkg), (extractfn)alpm_dep_get_name);
+          break;
+        case 'J': /* makedepends */
+          out += print_list(alpm_pkg_get_makedepends(pkg), (extractfn)alpm_dep_compute_string);
+          break;
+        case 'K': /* checkdepends */
+          out += print_list(alpm_pkg_get_checkdepends(pkg), (extractfn)alpm_dep_compute_string);
           break;
         case 'D': /* depends */
           out += print_list(alpm_pkg_get_depends(pkg), (extractfn)alpm_dep_compute_string);


### PR DESCRIPTION
- `%W`: Lists packages the supplied package/s is an optional dependency for.
     W is close to O for optdepends, i.e. the other direction.

  ```sh
  $ ./build/expac -S '%W' curl
  apache  bashtop  claws-mail  clevis  fio  freeradius  gap-packages  gcin inxi  ispin  mariadb  mariadb-lts  mkinitcpio-archiso  monitoring-plugins nextcloud  opensips  pciutils  systemd  translate-shell  vicious xfce4-screenshooter  xmms2
  ```

- `%J`: Lists makedepends. J because it's free.

  ```sh
  $ ./build/expac -S '%J' curl
  git  patchelf
  ```

- `%K`: Lists checkdepends. K because it's after J.

  ```sh
  $ ./build/expac -S '%K' curl
  valgrind
  ```
  
  Based on https://github.com/falconindy/expac/pull/39 by @eli-schwartz.